### PR TITLE
added suffixes to teams in SOUP

### DIFF
--- a/data/2021-02-27_penn_invitational_c.yaml
+++ b/data/2021-02-27_penn_invitational_c.yaml
@@ -43,7 +43,7 @@ Events:
 - name: Write It CAD It
 Teams:
 - number: 1
-  school: Abington Heights High School
+  school: Abington Heights High School 
   state: PA
 - number: 2
   school: Allentown Central Catholic High School
@@ -51,15 +51,19 @@ Teams:
   state: PA
 - number: 3
   school: Athens Area High School
+  suffix: A
   state: PA
 - number: 4
   school: Athens Area High School
+  suffix: B
   state: PA
 - number: 5
   school: Bayard Rustin High School
+  suffix: Rustin Blue
   state: PA
 - number: 6
   school: Bayard Rustin High School
+  suffix: Rustin Gold
   state: PA
 - number: 7
   school: Bridgewater-Raritan High School
@@ -75,12 +79,15 @@ Teams:
   state: MI
 - number: 11
   school: Carmel High School
+  suffix: Blue
   state: IN
 - number: 12
   school: Carmel High School
+  suffix: Gold
   state: IN
 - number: 13
   school: Centennial High School
+  suffix: B
   state: MD
 - number: 14
   school: Centennial High School
@@ -90,9 +97,11 @@ Teams:
   state: NY
 - number: 16
   school: Chattahoochee High School
+  suffix: A
   state: GA
 - number: 17
   school: Chattahoochee High School
+  suffix: B
   state: GA
 - number: 18
   school: Cherry Hill East High School
@@ -108,15 +117,19 @@ Teams:
   state: PA
 - number: 22
   school: Conestoga High School
+  suffix: B
   state: PA
 - number: 23
   school: Cumberland Valley High School
+  suffix: X
   state: PA
 - number: 24
   school: Cumberland Valley High School
+  suffix: Y
   state: PA
 - number: 25
   school: Cumberland Valley High School
+  suffix: Z
   state: PA
 - number: 26
   school: East Brunswick High School
@@ -126,30 +139,37 @@ Teams:
   state: NV
 - number: 28
   school: Fairfax High School
+  suffix: Blue
   state: VA
 - number: 29
   school: Fairfax High School
+  suffix: Gray
   state: VA
 - number: 30
   school: Fayetteville-Manlius High School
   state: NY
 - number: 31
   school: Harriton High School
+  suffix: A
   state: PA
 - number: 32
   school: Harriton High School
+  suffix: B
   state: PA
 - number: 33
   school: Hillsborough High School
   state: NJ
 - number: 34
   school: Hillsborough High School
+  suffix: Team 2
   state: NJ
 - number: 35
   school: Hunter College High School
+  suffix: A
   state: NY
 - number: 36
   school: Hunter College High School
+  suffix: B
   state: NY
 - number: 37
   school: Iolani School
@@ -160,9 +180,11 @@ Teams:
   state: NY
 - number: 39
   school: John P. Stevens High School
+  suffix: Team A
   state: NJ
 - number: 40
   school: John P. Stevens High School
+  suffix: Team B
   state: NJ
 - number: 41
   school: Julia R. Masterman Laboratory and Demonstration School
@@ -179,27 +201,34 @@ Teams:
   state: MA
 - number: 45
   school: Liberal Arts and Science Academy
+  suffix: A
   state: TX
 - number: 46
   school: Liberal Arts and Science Academy
+  suffix: B
   state: TX
 - number: 47
   school: Longmeadow High School
   state: MA
 - number: 48
   school: Lower Merion High School
+  suffix: Team A
   state: PA
 - number: 49
   school: Lower Merion High School
+  suffix: Team B
   state: PA
 - number: 50
   school: Mason High School
+  suffix: Alvin
   state: OH
 - number: 51
   school: Mason High School
+  suffix: Simon
   state: OH
 - number: 52
   school: Mason High School
+  suffix: Theodore
   state: OH
 - number: 53
   school: Merrimack High School
@@ -213,27 +242,33 @@ Teams:
   state: CA
 - number: 56
   school: Montgomery High School
+  suffix: A
   state: NJ
 - number: 57
   school: Montgomery High School
+  suffix: B
   state: NJ
 - number: 58
   school: North Penn High School
+  suffix: A
   state: PA
 - number: 59
   school: North Penn High School
+  suffix: B
   state: PA
 - number: 60
   school: North Pocono High School
   state: PA
 - number: 61
   school: North Pocono High School
+  suffix: Red
   state: PA
 - number: 62
   school: Parkland High School
   state: PA
 - number: 63
   school: Parkland High School
+  suffix: B
   state: PA
 - number: 64
   school: Philadelphia High School for Girls
@@ -246,6 +281,7 @@ Teams:
   state: NJ
 - number: 67
   school: Reservoir High School
+  suffix: Blue
   state: MD
 - number: 68
   school: Reservoir High School
@@ -258,27 +294,35 @@ Teams:
   state: NY
 - number: 71
   school: Saline High School
+  suffix: Blue
   state: MI
 - number: 72
   school: Saline High School
+  suffix: Yellow
   state: MI
 - number: 73
   school: Shady Side Academy Senior School
+  suffix: Blue
   state: PA
 - number: 74
   school: Shady Side Academy Senior School
+  suffix: Gold
   state: PA
 - number: 75
   school: Solon High School
+  suffix: A
   state: OH
 - number: 76
   school: Solon High School
+  suffix: B
   state: OH
 - number: 77
   school: South Brunswick High School
+  suffix: A
   state: NJ
 - number: 78
   school: South Brunswick High School
+  suffix: B
   state: NJ
 - number: 79
   school: Staten Island Technical High School
@@ -288,15 +332,19 @@ Teams:
   state: PA
 - number: 81
   school: Stuyvesant High School
+  suffix: Team A
   state: NY
 - number: 82
   school: Stuyvesant High School
+  suffix: Team B
   state: NY
 - number: 83
   school: Sylvania Southview High School
+  suffix: Brown
   state: OH
 - number: 84
   school: Sylvania Southview High School
+  suffix: Orange
   state: OH
 - number: 85
   school: Syosset High School
@@ -306,9 +354,11 @@ Teams:
   state: NJ
 - number: 87
   school: Mount Academy
+  suffix: A
   state: NY
 - number: 88
   school: Mount Academy
+  suffix: B
   state: NY
 - number: 89
   school: The Shipley School
@@ -319,18 +369,22 @@ Teams:
   state: VA
 - number: 91
   school: Townsend Harris High School
+  suffix: A
   state: NY
 - number: 92
   school: Townsend Harris High School
+  suffix: B
   state: NY
 - number: 93
   school: Upper Dublin High School
   state: PA
 - number: 94
   school: Ward Melville High School
+  suffix: A
   state: NY
 - number: 95
   school: Ward Melville High School
+  suffix: B
   state: NY
 - number: 96
   school: West Windsor-Plainsboro High School North
@@ -339,6 +393,7 @@ Teams:
 - number: 97
   school: West Windsor-Plainsboro High School North
   school abbreviation: WW-P High School North
+  suffix: 2
   state: NJ
 - number: 98
   school: West Windsor-Plainsboro High School South
@@ -347,6 +402,7 @@ Teams:
 - number: 99
   school: West Windsor-Plainsboro High School South
   school abbreviation: WW-P High School South
+  suffix: B
   state: NJ
 - number: 100
   school: Westborough High School

--- a/data/2021-02-27_penn_invitational_c.yaml
+++ b/data/2021-02-27_penn_invitational_c.yaml
@@ -43,7 +43,7 @@ Events:
 - name: Write It CAD It
 Teams:
 - number: 1
-  school: Abington Heights High School 
+  school: Abington Heights High School
   state: PA
 - number: 2
   school: Allentown Central Catholic High School


### PR DESCRIPTION
only added stuff that came after abbreviation in scilympiad. excluded suffix for A team if not included (school has 2 teams, B team named, but A team is just school name in scilympiad)