### PR TITLE
Paginate schools page

### DIFF
--- a/assets/results_schools/style.scss
+++ b/assets/results_schools/style.scss
@@ -38,4 +38,21 @@ main.schools-index {
       color: inherit;
     }
   }
+
+  margin-bottom: 96px;
+}
+
+ol.schools-letters-nav {
+  display: flex;
+  list-style: none;
+  justify-content: center;
+  font-size: 1.25em;
+  margin: 24px 0;
+}
+ol.schools-letters-nav li {
+  display: flex;
+}
+ol.schools-letters-nav > * + *::before {
+  content: '•';
+  margin: 0 0.25em;
 }

--- a/helpers/custom_helpers.rb
+++ b/helpers/custom_helpers.rb
@@ -287,25 +287,6 @@ module CustomHelpers
     "Qualified #{qualifiee} for the #{tournament.year} #{next_tournament}"
   end
 
-  def group_by_schools(interpreters)
-    interpreters
-      .values
-      .flat_map { |i| i.teams.map {|t| full_school_name(t) } }
-      .uniq
-      .sort_by { |t| t.downcase.tr('^A-Za-z0-9', '') }
-      .map do |s|
-      [
-        s,
-        interpreters.keys.map do |k|
-          teams = interpreters[k].teams.select {|t| full_school_name(t) == s }
-          next if teams.empty?
-
-          [k, teams.map(&:rank).sort.map(&:ordinalize)]
-        end.compact.to_h
-      ]
-    end.to_h
-  end
-
   def csv_schools(interpreters)
     CSV.generate do |csv|
       interpreters

--- a/source/results/schools.html.erb
+++ b/source/results/schools.html.erb
@@ -2,43 +2,10 @@
 title: By School | Duosmium Results
 description: Science Olympiad tournament results grouped by schools!
 ---
-<header class="schools-index jumbotron jumbotron-fluid bg-primary mb-5">
-  <div class="container">
-    <h1 class="text-light">
-      <a href="index.html">All Results</a> by School
-    </h1>
-  </div>
-</header>
-
-<main class="schools-index container">
-  <% group_by_schools(interpreters).each do |school, filenames| %>
-    <h2 id="<%= school.tr(' ', '_') %>">
-      <a href="#<%= school.tr(' ', '_') %>"><%= school %></a>
-    </h2>
-    <hr>
-    <ul>
-      <% filenames.each do |f, ranks| %>
-        <li>
-          <a href="<%= f %>.html">
-            <% tournament = interpreters[f].tournament %>
-            <%= tournament.year %>
-            <% if !tournament.short_name.nil? %>
-              <%= tournament.short_name %> (Div. <%= tournament.division %>)
-            <% else %>
-              <%= tournament_title(tournament) %> (Div. <%= tournament.division %>)
-            <% end %>
-          </a>
-          — <%= ranks.join ', ' %>
-        </li>
-      <% end %>
-    </ul>
-  <% end %>
-
-  <a href="#top" class="btn btn-float btn-light" id="scroll-back" role="button" aria-label="scroll to top">
-    <svg id="expand_less" role="img" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"/>
-      <path d="M0 0h24v24H0z" fill="none"/>
-    </svg>
-  </a>
-
-</main>
+<script>
+if (window.location.hash) {
+  window.location.href = `/results/schools/${window.location.hash[1].toLowerCase()}.html${window.location.hash}`
+} else {
+  window.location.href = '/results/schools/a.html'
+}
+</script>

--- a/source/results/schools_template.html.erb
+++ b/source/results/schools_template.html.erb
@@ -1,0 +1,56 @@
+---
+title: By School | Duosmium Results
+description: Science Olympiad tournament results grouped by schools!
+---
+<header class="schools-index jumbotron jumbotron-fluid bg-primary mb-5">
+  <div class="container">
+    <h1 class="text-light">
+      <a href="index.html">All Results</a> by School
+    </h1>
+  </div>
+</header>
+
+<main class="schools-index container">
+  <nav>
+    <ol class="schools-letters-nav">
+      <% letters.each do |letter| %>
+        <li>
+          <a href="<%= letter %>.html">
+            <%= letter.upcase %>
+          </a>
+        </li>
+      <% end %>
+    </ol>
+  </nav>
+
+  <% schools.each do |school, filenames| %>
+    <h2 id="<%= school.tr(' ', '_') %>">
+      <a href="#<%= school.tr(' ', '_') %>"><%= school %></a>
+    </h2>
+    <hr>
+    <ul>
+      <% filenames.each do |f, ranks| %>
+        <li>
+          <a href="<%= f %>.html">
+            <% tournament = interpreters[f].tournament %>
+            <%= tournament.year %>
+            <% if !tournament.short_name.nil? %>
+              <%= tournament.short_name %> (Div. <%= tournament.division %>)
+            <% else %>
+              <%= tournament_title(tournament) %> (Div. <%= tournament.division %>)
+            <% end %>
+          </a>
+          — <%= ranks.join ', ' %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <a href="#top" class="btn btn-float btn-light" id="scroll-back" role="button" aria-label="scroll to top">
+    <svg id="expand_less" role="img" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"/>
+      <path d="M0 0h24v24H0z" fill="none"/>
+    </svg>
+  </a>
+
+</main>


### PR DESCRIPTION
Fixes #19 

This PR creates a new page `/results/schools/{letter}.html` for each letter that has schools. The original `/results/schools.html` will automatically redirect to the `a` page, unless a hash is provided, where it will redirect to the correct page (naively taking the first letter).